### PR TITLE
Fix flaky test in org.jsmart.zerocode.core.httpclient.BasicHttpClientTest

### DIFF
--- a/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -25,6 +26,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
 
 public class BasicHttpClientTest {
     private BasicHttpClient basicHttpClient;
@@ -56,7 +58,20 @@ public class BasicHttpClientTest {
         String reqBodyAsString = "{\"Name\":\"Larry Pg\",\"Company\":\"Amazon\",\"Title\":\"CEO\"}";
         RequestBuilder requestBuilder = basicHttpClient.createRequestBuilder("/api/v1/founder", "POST", header, reqBodyAsString);
         String nameValuePairString = EntityUtils.toString(requestBuilder.getEntity(), "UTF-8");
-        assertThat(nameValuePairString, is("Company=Amazon&Title=CEO&Name=Larry+Pg"));
+
+        String expected = "Company=Amazon&Title=CEO&Name=Larry+Pg";
+        String[] expectedStrs = expected.split("&");
+
+        String[] actualStrs = nameValuePairString.split("&");
+
+        Arrays.sort(expectedStrs);
+        Arrays.sort(actualStrs);
+
+        assertEquals(expectedStrs.length, actualStrs.length);
+        
+        for (int i = 0; i < expectedStrs.length; i++) {
+            assertEquals(expectedStrs[i], actualStrs[i]);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Description
The test in the test class `org.jsmart.zerocode.core.httpclient.BasicHttpClientTest` could fail because the code assumes deterministic implementation of a non-deterministic specification

### Steps to reproduce
Compile the module where the test is, and all modules it depends on, but skip tests
```
mvn install -pl core -am -DskipTests
```
Run the test to check that it passes
```
mvn -pl core test -Dtest=org.jsmart.zerocode.core.httpclient.BasicHttpClientTest#createRequestBuilder_spaceInKeyValue
```
Run the test with the NonDex tool
```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.jsmart.zerocode.core.httpclient.BasicHttpClientTest#createRequestBuilder_spaceInKeyValue
```

### Expected Behavior
All tests should pass

### Actual Behavior
Detected test failure with the following NonDex configuration:
nondexFilter=.*
nondexMode=FULL
nondexSeed=933178
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false

The test is failing due to a non-deterministic order between the key-value pairs:
Expected: "Company=Amazon&Title=CEO&Name=Larry+Pg"
Actual: "Title=CEO&Name=Larry+Pg&Company=Amazon"

### Findings
The test `createRequestBuilder_spaceInKeyValue()` called `BasicHttpClient.createRequestBuilder()` with a JSON string as the request body. This method subsequently invoked `BasicHttpClient.createFormUrlEncodedRequestBuilder()`, which converted the JSON string into a Map object. Since the Map interface does not guarantee any specific order for its entries, when toString() is called on the entries of this map to create a form-urlencoded string, the order of the parameters is not consistent. The test would fail because it expects the parameters to appear in a specific order, but the actual order of parameters in the resulting string might not match the expected order.

### Fix
To fix this issue, we can split both the expected string and the actual string into arrays of key-value pairs using the delimiter `&` and then sort both arrays. After that, we can compare the lengths of the sorted arrays and iterate through the sorted arrays and compared each key-value pair. In this way, the test will be no longer affected by the arbitrary order of parameters.